### PR TITLE
Turning GridFTP logging on by default

### DIFF
--- a/source/globus/connect/server/io/__init__.py
+++ b/source/globus/connect/server/io/__init__.py
@@ -319,7 +319,7 @@ server
         conf_file = file(conf_file_name, "w")
         try:
             conf_file.write("log_single /var/log/gridftp.log\n")
-            conf_file.write("log_level WARN\n")
+            conf_file.write("log_level ERROR,WARN\n")
             os.symlink(conf_file_name, conf_link_name)
         finally:
             conf_file.close()


### PR DESCRIPTION
After a discussion with Stu about logging for the Globus Connect Server components, we came to the idea that it might be helpful to have logging for the GridFTP service turned on by default. Stu asked me to modify Globus Connect Server Setup to make this happen, and to provide this logging with 'sane' defaults. My efforts thus far are represented in this pull request. I have tested these changes against CentOS 7, Ubuntu 14.04, and SLES 11sp3. Your thoughts and feedback on the proposed modifications would be much appreciated.
