### PR TITLE
Update __init__.py

### DIFF
--- a/source/globus/connect/server/__init__.py
+++ b/source/globus/connect/server/__init__.py
@@ -233,7 +233,13 @@ def get_api(conf):
 
 def is_latest_version(force=False):
     data_version = pkgutil.get_data("globus.connect.server", "version").strip()
-    published_version = urlopen(LATEST_VERSION_URI).read().strip()
+
+    try:
+        published_version = urlopen(LATEST_VERSION_URI).read().strip()
+    except IOError as e:
+        print("Unable to get version info from: " + LATEST_VERSION_URI + \
+              "\n" + str(e) + "\nSkipping version check.", file=sys.stderr)
+        return False
 
     fieldshift = 1000
 


### PR DESCRIPTION
https://globusonline.zendesk.com/agent/tickets/304583

Lukasz wanted gcs setup to not automatically fail if it was unable to connect to the version URI. His use case involves a system with very restrictive firewall rules. Stu told me to go ahead and take care of this. I put the url read into a try/except block to catch the time out errors he was seeing due to his outbound connection attempt being blocked by the firewall. Please let me know if this change is acceptable.
