### PR TITLE
Fix CILogon name for Texas A&M University

### DIFF
--- a/source/globus/connect/server/configfile.py
+++ b/source/globus/connect/server/configfile.py
@@ -257,7 +257,7 @@ class ConfigFile(configparser.ConfigParser):
                         "Stevens Institute of Technology",
                         "Stony Brook University",
                         "Syracuse University",
-                        "Texas A &amp; M University",
+                        "Texas A & M University",
                         "Texas State University - San Marcos",
                         "Texas Tech University",
                         "The Broad Institute of MIT and Harvard",


### PR DESCRIPTION
This fix also means that globus-connect-server-io-setup can be run without having to manually replace the "&amp;" with "&" in /var/lib/globus-connect-server/gsi-authz.conf.  I verified this works by manually modifying /usr/lib/python2.6/site-packages/globus/connect/server/configfile.py with this change.
