### PR TITLE
Added missingok to logrotate.

### DIFF
--- a/source/globus/connect/server/io/__init__.py
+++ b/source/globus/connect/server/io/__init__.py
@@ -368,6 +368,7 @@ server
             logrotate_file.write("/var/log/gridftp.log {\n")
             logrotate_file.write("   rotate 4\n")
             logrotate_file.write("   weekly\n")
+            logrotate_file.write("   missingok\n")
             logrotate_file.write("   compress\n")
             logrotate_file.write("   create 644 root root\n")
             logrotate_file.write("   postrotate\n")


### PR DESCRIPTION
If the log file destination changes to a custom location, then cron + logrotate 
will complain about not being able to find the gridftp.log in the standard location.

If root mail is configured to send mail out, then this failure message gets emailed daily.
