### PR TITLE
Update __init__.py

### DIFF
--- a/source/globus/connect/server/__init__.py
+++ b/source/globus/connect/server/__init__.py
@@ -73,7 +73,7 @@ def is_ec2():
     except IOError:
         pass
 
-    if value is not None and "404 - Not Found" in value:
+    if value is not None and re.search(r"404 - (File or directory )*(n|N)ot (f|F)ound", value):
         value = None
 
     return value is not None


### PR DESCRIPTION
Prevent falsely detecting Azure nodes as ec2 nodes.

globus-connect-server-setup was falsely detecting a user's Azure node as an ec2 node, and dumping the 404 message that 'value = urlopen(url).read()' was getting into the GridFTP config data_interface value as a result. This change modifies the line that detects if a 404 was returned from 'value = urlopen(url).read()' so that it also catches the 404 returned in Azure's environment. Issue was detected in ticket #[308313](https://globusonline.zendesk.com/agent/tickets/308313) and user verified that change resolved their issue.